### PR TITLE
Handle special characters in database, schema and table name

### DIFF
--- a/snowflake/src/main/java/org/apache/iceberg/snowflake/JdbcSnowflakeClient.java
+++ b/snowflake/src/main/java/org/apache/iceberg/snowflake/JdbcSnowflakeClient.java
@@ -143,7 +143,7 @@ class JdbcSnowflakeClient implements SnowflakeClient {
         "databaseExists requires a DATABASE identifier, got '%s'",
         database);
 
-    final String finalQuery = "SHOW SCHEMAS IN IDENTIFIER(?) LIMIT 1";
+    final String finalQuery = "SHOW SCHEMAS IN DATABASE IDENTIFIER(?) LIMIT 1";
 
     List<SnowflakeIdentifier> schemas;
     try {
@@ -179,7 +179,7 @@ class JdbcSnowflakeClient implements SnowflakeClient {
       return false;
     }
 
-    final String finalQuery = "SHOW TABLES IN IDENTIFIER(?) LIMIT 1";
+    final String finalQuery = "SHOW TABLES IN SCHEMA IDENTIFIER(?) LIMIT 1";
 
     List<SnowflakeIdentifier> schemas;
     try {

--- a/snowflake/src/main/java/org/apache/iceberg/snowflake/JdbcSnowflakeClient.java
+++ b/snowflake/src/main/java/org/apache/iceberg/snowflake/JdbcSnowflakeClient.java
@@ -136,30 +136,6 @@ class JdbcSnowflakeClient implements SnowflakeClient {
     this.queryHarness = queryHarness;
   }
 
-  /**
-   * For rare cases where PreparedStatements aren't supported for user-supplied identifiers intended
-   * for use in special LIKE clauses, we can sanitize by "broadening" the identifier with
-   * single-character wildcards and manually post-filter client-side.
-   *
-   * <p>Note: This sanitization approach intentionally "broadens" the scope of matching results;
-   * callers must be able to handle this method returning an all-wildcard expression; i.e. the
-   * caller must treat the usage of the LIKE clause as only an optional optimization, and should
-   * post-filter for correctness as if the LIKE clause wasn't present in the query at all.
-   */
-  @VisibleForTesting
-  String sanitizeIdentifierWithWildcardForLikeClause(String identifier) {
-    // Restrict identifiers to the "Unquoted object identifiers" synax documented at
-    // https://docs.snowflake.com/en/sql-reference/identifiers-syntax.html
-    //
-    // Use a strict allowlist of characters, replace everything *not* matching the character set
-    // with "_", which is used as a single-character wildcard in Snowflake.
-    String sanitized = identifier.replaceAll("[^a-zA-Z0-9_$]", "_");
-    if (sanitized.startsWith("$")) {
-      sanitized = "_" + sanitized.substring(1);
-    }
-    return sanitized;
-  }
-
   @Override
   public boolean databaseExists(SnowflakeIdentifier database) {
     Preconditions.checkArgument(
@@ -167,29 +143,29 @@ class JdbcSnowflakeClient implements SnowflakeClient {
         "databaseExists requires a DATABASE identifier, got '%s'",
         database);
 
-    // Due to current limitations in PreparedStatement parameters for the LIKE clause in
-    // SHOW DATABASES queries, we'll use a fairly limited allowlist for identifier characters,
-    // using wildcards for non-allowed characters, and post-filter for matching.
-    final String finalQuery =
-        String.format(
-            "SHOW DATABASES LIKE '%s' IN ACCOUNT",
-            sanitizeIdentifierWithWildcardForLikeClause(database.databaseName()));
-    List<SnowflakeIdentifier> databases;
+    final String finalQuery = "SHOW SCHEMAS IN IDENTIFIER(?) LIMIT 1";
+
+    List<SnowflakeIdentifier> schemas;
     try {
-      databases =
+      schemas =
           connectionPool.run(
-              conn -> queryHarness.query(conn, finalQuery, DATABASE_RESULT_SET_HANDLER));
+              conn ->
+                  queryHarness.query(
+                      conn,
+                      finalQuery,
+                      SCHEMA_RESULT_SET_HANDLER,
+                      SnowflakeIdentifier.toIdentifierString(database.databaseName())));
     } catch (SQLException e) {
+      if (e.getErrorCode() == 2003 && e.getMessage().contains("does not exist")) {
+        return false;
+      }
       throw new UncheckedSQLException(e, "Failed to check if database '%s' exists", database);
     } catch (InterruptedException e) {
       throw new UncheckedInterruptedException(
           e, "Interrupted while checking if database '%s' exists", database);
     }
 
-    // Filter to handle the edge case of '_' appearing as a wildcard that can't be remapped the way
-    // it can for predicates in SELECT statements.
-    databases.removeIf(db -> !database.databaseName().equalsIgnoreCase(db.databaseName()));
-    return !databases.isEmpty();
+    return !schemas.isEmpty();
   }
 
   @Override
@@ -203,31 +179,26 @@ class JdbcSnowflakeClient implements SnowflakeClient {
       return false;
     }
 
-    // Due to current limitations in PreparedStatement parameters for the LIKE clause in
-    // SHOW SCHEMAS queries, we'll use a fairly limited allowlist for identifier characters,
-    // using wildcards for non-allowed characters, and post-filter for matching.
-    final String finalQuery =
-        String.format(
-            "SHOW SCHEMAS LIKE '%s' IN DATABASE IDENTIFIER(?)",
-            sanitizeIdentifierWithWildcardForLikeClause(schema.schemaName()));
+    final String finalQuery = "SHOW TABLES IN IDENTIFIER(?) LIMIT 1";
+
     List<SnowflakeIdentifier> schemas;
     try {
       schemas =
           connectionPool.run(
               conn ->
                   queryHarness.query(
-                      conn, finalQuery, SCHEMA_RESULT_SET_HANDLER, schema.databaseName()));
+                      conn, finalQuery, TABLE_RESULT_SET_HANDLER, schema.toIdentifierString()));
     } catch (SQLException e) {
+      if (e.getErrorCode() == 2003 && e.getMessage().contains("does not exist")) {
+        return false;
+      }
       throw new UncheckedSQLException(e, "Failed to check if schema '%s' exists", schema);
     } catch (InterruptedException e) {
       throw new UncheckedInterruptedException(
           e, "Interrupted while checking if schema '%s' exists", schema);
     }
 
-    // Filter to handle the edge case of '_' appearing as a wildcard that can't be remapped the way
-    // it can for predicates in SELECT statements.
-    schemas.removeIf(sc -> !schema.schemaName().equalsIgnoreCase(sc.schemaName()));
-    return !schemas.isEmpty();
+    return true;
   }
 
   @Override

--- a/snowflake/src/main/java/org/apache/iceberg/snowflake/SnowflakeCatalog.java
+++ b/snowflake/src/main/java/org/apache/iceberg/snowflake/SnowflakeCatalog.java
@@ -45,6 +45,7 @@ public class SnowflakeCatalog extends BaseMetastoreCatalog
     implements Closeable, SupportsNamespaces, Configurable<Object> {
   private static final String DEFAULT_CATALOG_NAME = "snowflake_catalog";
   private static final String DEFAULT_FILE_IO_IMPL = "org.apache.iceberg.io.ResolvingFileIO";
+  private static final String APP_IDENTIFIER = "iceberg-SDK";
 
   // Injectable factory for testing purposes.
   static class FileIOFactory {
@@ -109,6 +110,10 @@ public class SnowflakeCatalog extends BaseMetastoreCatalog
               + " JDBC driver to your jars/packages",
           cnfe);
     }
+
+    // Populate application identifier in jdbc client
+    properties.put("application", APP_IDENTIFIER);
+
     JdbcClientPool connectionPool = new JdbcClientPool(uri, properties);
 
     initialize(name, new JdbcSnowflakeClient(connectionPool), new FileIOFactory(), properties);

--- a/snowflake/src/main/java/org/apache/iceberg/snowflake/SnowflakeIdentifier.java
+++ b/snowflake/src/main/java/org/apache/iceberg/snowflake/SnowflakeIdentifier.java
@@ -18,6 +18,9 @@
  */
 package org.apache.iceberg.snowflake;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Objects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
@@ -116,14 +119,42 @@ class SnowflakeIdentifier {
   public String toIdentifierString() {
     switch (type()) {
       case TABLE:
-        return String.format("%s.%s.%s", databaseName, schemaName, tableName);
+        return String.format(
+            "%s.%s.%s",
+            toIdentifierString(databaseName),
+            toIdentifierString(schemaName),
+            toIdentifierString(tableName));
       case SCHEMA:
-        return String.format("%s.%s", databaseName, schemaName);
+        return String.format(
+            "%s.%s", toIdentifierString(databaseName), toIdentifierString(schemaName));
       case DATABASE:
-        return databaseName;
+        return toIdentifierString(databaseName);
       default:
         return "";
     }
+  }
+
+  /**
+   * Returns the supplied identifier String as a String suitable for use in a Snowflake IDENTIFIER
+   * param.
+   */
+  @VisibleForTesting
+  static String toIdentifierString(String identifier) {
+    // Identifier with special characters are case-sensitive while regular identifiers (no special
+    // characters) are
+    // case-insensitive. More details could be found here.
+    // https://docs.snowflake.com/en/sql-reference/identifiers-syntax.html
+    //
+    // Identifiers with single and double qoutes are not supported.
+    Pattern noSpecialChars = Pattern.compile("[^a-z0-9]", Pattern.CASE_INSENSITIVE);
+    Matcher check = noSpecialChars.matcher(identifier);
+    String sanitized = identifier;
+    if (check.find()) {
+
+      // Database names with single or double quotes are not supported
+      sanitized = "\"" + sanitized + "\"";
+    }
+    return sanitized;
   }
 
   @Override

--- a/snowflake/src/main/java/org/apache/iceberg/snowflake/SnowflakeIdentifier.java
+++ b/snowflake/src/main/java/org/apache/iceberg/snowflake/SnowflakeIdentifier.java
@@ -145,13 +145,15 @@ class SnowflakeIdentifier {
     // case-insensitive. More details could be found here.
     // https://docs.snowflake.com/en/sql-reference/identifiers-syntax.html
     //
-    // Identifiers with single and double qoutes are not supported.
     Pattern noSpecialChars = Pattern.compile("[^a-z0-9]", Pattern.CASE_INSENSITIVE);
     Matcher check = noSpecialChars.matcher(identifier);
     String sanitized = identifier;
     if (check.find()) {
 
-      // Database names with single or double quotes are not supported
+      // Escape double quotes correctly
+      sanitized = sanitized.replace("\"", "\"\"");
+
+      // Add double quotes to evaluate identifier as quoted
       sanitized = "\"" + sanitized + "\"";
     }
     return sanitized;

--- a/snowflake/src/test/java/org/apache/iceberg/snowflake/JdbcSnowflakeClientTest.java
+++ b/snowflake/src/test/java/org/apache/iceberg/snowflake/JdbcSnowflakeClientTest.java
@@ -88,7 +88,7 @@ public class JdbcSnowflakeClientTest {
     verify(mockQueryHarness)
         .query(
             eq(mockConnection),
-            eq("SHOW SCHEMAS IN IDENTIFIER(?) LIMIT 1"),
+            eq("SHOW SCHEMAS IN DATABASE IDENTIFIER(?) LIMIT 1"),
             any(JdbcSnowflakeClient.ResultSetParser.class),
             eq("\"DB_1\""));
   }
@@ -106,7 +106,7 @@ public class JdbcSnowflakeClientTest {
     verify(mockQueryHarness)
         .query(
             eq(mockConnection),
-            eq("SHOW SCHEMAS IN IDENTIFIER(?) LIMIT 1"),
+            eq("SHOW SCHEMAS IN DATABASE IDENTIFIER(?) LIMIT 1"),
             any(JdbcSnowflakeClient.ResultSetParser.class),
             eq("\"$DB_1$.!@#%^&*\""));
   }
@@ -138,13 +138,13 @@ public class JdbcSnowflakeClientTest {
     verify(mockQueryHarness)
         .query(
             eq(mockConnection),
-            eq("SHOW SCHEMAS IN IDENTIFIER(?) LIMIT 1"),
+            eq("SHOW SCHEMAS IN DATABASE IDENTIFIER(?) LIMIT 1"),
             any(JdbcSnowflakeClient.ResultSetParser.class),
             eq("DB1"));
     verify(mockQueryHarness)
         .query(
             eq(mockConnection),
-            eq("SHOW TABLES IN IDENTIFIER(?) LIMIT 1"),
+            eq("SHOW TABLES IN SCHEMA IDENTIFIER(?) LIMIT 1"),
             any(JdbcSnowflakeClient.ResultSetParser.class),
             eq("DB1.SCHEMA1"));
   }
@@ -168,13 +168,13 @@ public class JdbcSnowflakeClientTest {
     verify(mockQueryHarness)
         .query(
             eq(mockConnection),
-            eq("SHOW SCHEMAS IN IDENTIFIER(?) LIMIT 1"),
+            eq("SHOW SCHEMAS IN DATABASE IDENTIFIER(?) LIMIT 1"),
             any(JdbcSnowflakeClient.ResultSetParser.class),
             eq("\"DB_1\""));
     verify(mockQueryHarness)
         .query(
             eq(mockConnection),
-            eq("SHOW TABLES IN IDENTIFIER(?) LIMIT 1"),
+            eq("SHOW TABLES IN SCHEMA IDENTIFIER(?) LIMIT 1"),
             any(JdbcSnowflakeClient.ResultSetParser.class),
             eq("\"DB_1\".\"$SCHEMA_1$.!@#%^&*\""));
   }


### PR DESCRIPTION
Currently the catalog is unable to handle databases or schema with special characters. This limitation is due to sanitizing of the parameter for the like clause of SQL statements (which is not well supported by PreparedStatement) to determine if a database or schema exists (eg: SHOW DATABASES LIKE '%s' IN ACCOUNT). The alternative proposal is to check for existence of schemas in a database (SHOW SCHEMAS/TABLES IN IDENTIFIER(?) LIMIT 1) which would throw an exception if the database/schema would not exist. This avoids using the like statement and we can pass in the database names with special characters as quoted identifiers (more details at https://docs.snowflake.com/en/sql-reference/identifiers-syntax.html).
The PR also adds application parameter as an identifier to underlying jdbc client. https://docs.snowflake.com/en/user-guide/jdbc-parameters.html#application