### PR TITLE
Add application identifier for Snowflake JDBC driver

### DIFF
--- a/snowflake/src/main/java/org/apache/iceberg/snowflake/SnowflakeCatalog.java
+++ b/snowflake/src/main/java/org/apache/iceberg/snowflake/SnowflakeCatalog.java
@@ -45,6 +45,7 @@ public class SnowflakeCatalog extends BaseMetastoreCatalog
     implements Closeable, SupportsNamespaces, Configurable<Object> {
   private static final String DEFAULT_CATALOG_NAME = "snowflake_catalog";
   private static final String DEFAULT_FILE_IO_IMPL = "org.apache.iceberg.io.ResolvingFileIO";
+  private static final String APP_IDENTIFIER = "iceberg-SDK";
 
   // Injectable factory for testing purposes.
   static class FileIOFactory {
@@ -109,6 +110,10 @@ public class SnowflakeCatalog extends BaseMetastoreCatalog
               + " JDBC driver to your jars/packages",
           cnfe);
     }
+
+    // Populate application identifier in jdbc client
+    properties.put("application", APP_IDENTIFIER);
+
     JdbcClientPool connectionPool = new JdbcClientPool(uri, properties);
 
     initialize(name, new JdbcSnowflakeClient(connectionPool), new FileIOFactory(), properties);


### PR DESCRIPTION
Adding application identifier to the JDBC driver used by snowflake catalog. This helps identify partner applications (iceberg SDK in this case) that connect via JDBC driver. More details about the JDBC parameter could be found here https://docs.snowflake.com/en/user-guide/jdbc-parameters.html#application