### PR TITLE
Add unique JDBC application identifier and user agent header

### DIFF
--- a/versions.props
+++ b/versions.props
@@ -28,7 +28,7 @@ org.scala-lang.modules:scala-collection-compat_2.12 = 2.6.0
 org.scala-lang.modules:scala-collection-compat_2.13 = 2.6.0
 com.emc.ecs:object-client-bundle = 3.3.2
 org.immutables:value = 2.9.2
-net.snowflake:snowflake-jdbc = 3.13.22
+net.snowflake:snowflake-jdbc = 3.13.28
 io.delta:delta-standalone_* = 0.6.0
 
 # test deps


### PR DESCRIPTION
Make JDBC application identifier unique for each catalog initialization and add another JDBC property to track the application identifier in the JDBC web request's user agent header.
Also updating to the latest version of snowflake's JDBC driver.