### PR TITLE
Introduce two properties for reading the connection timeout and socket timeout

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -527,10 +527,13 @@ public class HTTPClient implements RESTClient {
 
       ConnectionConfig connectionConfig = getConnectionConfig(properties);
 
-      HttpClientConnectionManager connectionManager =
-          getConnectionManager(properties, connectionConfig);
-
-      return new HTTPClient(uri, baseHeaders, mapper, interceptor, properties, connectionManager);
+      return new HTTPClient(
+          uri,
+          baseHeaders,
+          mapper,
+          interceptor,
+          properties,
+          getConnectionManager(properties, connectionConfig));
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -98,17 +98,17 @@ public class HTTPClient implements RESTClient {
 
     HttpClientBuilder clientBuilder = HttpClients.custom();
 
-    String connectionTimeout = properties.get(REST_CONNECTION_TIMEOUT);
-    String socketTimeout = properties.get(REST_SOCKET_TIMEOUT);
+    Long connectionTimeout = PropertyUtil.propertyAsNullableLong(properties, REST_CONNECTION_TIMEOUT);
+    Integer socketTimeout = PropertyUtil.propertyAsNullableInt(properties, REST_SOCKET_TIMEOUT);
 
     ConnectionConfig.Builder connConfigBuilder = ConnectionConfig.custom();
 
     if (connectionTimeout != null) {
-      connConfigBuilder.setConnectTimeout(Long.parseLong(connectionTimeout), TimeUnit.SECONDS);
+      connConfigBuilder.setConnectTimeout(connectionTimeout, TimeUnit.SECONDS);
     }
 
     if (socketTimeout != null) {
-      connConfigBuilder.setSocketTimeout(Integer.parseInt(socketTimeout), TimeUnit.SECONDS);
+      connConfigBuilder.setSocketTimeout(socketTimeout, TimeUnit.SECONDS);
     }
 
     HttpClientConnectionManager connectionManager =

--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -465,7 +465,9 @@ public class HTTPClient implements RESTClient {
         PropertyUtil.propertyAsNullableLong(properties, REST_CONNECTION_TIMEOUT);
     Integer socketTimeout = PropertyUtil.propertyAsNullableInt(properties, REST_SOCKET_TIMEOUT);
 
-    if (connectionTimeout == null && socketTimeout == null) return null;
+    if (connectionTimeout == null && socketTimeout == null) {
+      return null;
+    }
 
     ConnectionConfig.Builder connConfigBuilder = ConnectionConfig.custom();
 

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
@@ -35,6 +35,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
+import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.core5.http.EntityDetails;
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpRequestInterceptor;
@@ -131,6 +132,21 @@ public class TestHTTPClient {
 
     assertThat(interceptor).isInstanceOf(TestHttpRequestInterceptor.class);
     assertThat(((TestHttpRequestInterceptor) interceptor).properties).isEqualTo(properties);
+  }
+
+  @Test
+  public void testHttpClientGetConnectionConfig() {
+    long connectionTimeout = 10000L;
+    int socketTimeout = 100;
+    Map<String, String> properties =
+        ImmutableMap.of(
+            HTTPClient.REST_CONNECTION_TIMEOUT, String.valueOf(connectionTimeout),
+            HTTPClient.REST_SOCKET_TIMEOUT, String.valueOf(socketTimeout));
+
+    ConnectionConfig connectionConfig = HTTPClient.getConnectionConfig(properties);
+
+    assertThat(connectionConfig.getConnectTimeout().getDuration()).isEqualTo(connectionTimeout);
+    assertThat(connectionConfig.getSocketTimeout().getDuration()).isEqualTo(socketTimeout);
   }
 
   public static void testHttpMethodOnSuccess(HttpMethod method) throws JsonProcessingException {


### PR DESCRIPTION
Introducing two new properties to allow configuring the HTTPClient connection timeout and socket timeout. The values for these properties are accepted via the properties map of the HTTPClientBuilder.  