### PR TITLE
Extend httpclientbuilder to allow setting proxy

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -476,9 +476,9 @@ public class HTTPClient implements RESTClient {
       return this;
     }
 
-    public Builder withProxy(String hostIp) {
-      Preconditions.checkNotNull(hostIp, "Invalid hostIp for http client proxy: null");
-      this.proxy = new HttpHost(hostIp);
+    public Builder withProxy(String hostname, int port) {
+      Preconditions.checkNotNull(hostname, "Invalid hostIp for http client proxy: null");
+      this.proxy = new HttpHost(hostname, port);
       return this;
     }
 

--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -477,7 +477,7 @@ public class HTTPClient implements RESTClient {
     }
 
     public Builder withProxy(String hostname, int port) {
-      Preconditions.checkNotNull(hostname, "Invalid hostIp for http client proxy: null");
+      Preconditions.checkNotNull(hostname, "Invalid hostname for http client proxy: null");
       this.proxy = new HttpHost(hostname, port);
       return this;
     }


### PR DESCRIPTION
Code changes to extend the HTTPClientBuilder to allow setting a proxy on the internal httpclient.